### PR TITLE
Consider common environment variables in the download script

### DIFF
--- a/download-lib.js
+++ b/download-lib.js
@@ -1,7 +1,11 @@
 const { HttpsProxyAgent } = require("https-proxy-agent");
 const { DownloaderHelper } = require("node-downloader-helper");
 const { version } = require("./package.json");
-const { platform, arch } = process;
+
+// Get the platform and architecture based on environment variables,
+// falling back to the current platform and architecture
+const platform = process.env.npm_config_target_platform || process.env.npm_config_platform || process.platform;
+const arch = process.env.npm_config_target_arch || process.env.npm_config_arch || process.arch;
 
 const DOWNLOADS_BASE_URL = "https://github.com/matrix-org/matrix-rust-sdk/releases/download";
 const CURRENT_VERSION = `matrix-sdk-crypto-nodejs-v${version}`;


### PR DESCRIPTION
This changes the build install script to consider common environment variables to override the platform and arch for which it should download the bindings.
Those environment variable are understood by tools like node-gyp, so it is quite common to set them when you intend to install dependencies for another platform/arch than the current one.

In hookshot I had to work around this with a script which did the downloading itself: https://github.com/matrix-org/matrix-hookshot/pull/801/files#diff-3c8e5150f378e5d2ddc0c7d17a724aa76b5fb03970555ee56c6ecf28eb690a39