### PR TITLE
Release v0.1.0 beta.8

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -133,3 +133,4 @@ jobs:
           package: package.json
           access: public
           token: ${{ secrets.NPM_TOKEN }}
+          ignore-scripts: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Matrix-Rust-SDK Node.js Bindings
 
+## 0.1.0-beta.8 - 2023-08-01
+
+-   Don't skip downloading the native library when installing from npm.
+
 ## 0.1.0-beta.7 - 2023-08-01
 
 -   Expose bindings for secure key backup. [#7](https://github.com/matrix-org/matrix-rust-sdk-crypto-nodejs/pull/7)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@matrix-org/matrix-sdk-crypto-nodejs",
-    "version": "0.1.0-beta.7",
+    "version": "0.1.0-beta.8",
     "main": "index.js",
     "types": "index.d.ts",
     "napi": {


### PR DESCRIPTION
This should fix a problem introduced in the last release that caused `npm install`s of this package to not download the native bindings.

Thus, the previous release should be deprecated (or removed if possible, but since it has public dependants, it probably can't be).