### PR TITLE
Add export_room_keys_for_session

### DIFF
--- a/src/machine.rs
+++ b/src/machine.rs
@@ -614,7 +614,7 @@ impl OlmMachine {
             &self
                 .inner
                 .export_room_keys(|session| {
-                    session.session_id() == session_id && session.room_id().eq(&room_id)
+                    session.session_id() == session_id && session.room_id() == &room_id
                 })
                 .await
                 .map_err(into_err)?,

--- a/src/machine.rs
+++ b/src/machine.rs
@@ -602,14 +602,24 @@ impl OlmMachine {
         }
     }
 
-    /// Export room keys in unencrypted format for a given session_id. This currently exports a 
-    /// json blob.
+    /// Export room keys in unencrypted format for a given session_id.
+    /// This currently exports a json blob.
     #[napi]
-    pub async fn export_room_keys_for_session(&self, room_id: String, session_id: String) -> napi::Result<String> {
+    pub async fn export_room_keys_for_session(
+        &self,
+        room_id: String,
+        session_id: String,
+    ) -> napi::Result<String> {
         serde_json::to_string(
-            &self.inner.export_room_keys(|session| session.session_id() == session_id && session.room_id().eq(&room_id))
-            .await.map_err(into_err)?
-        ).map_err(into_err)
+            &self
+                .inner
+                .export_room_keys(|session| {
+                    session.session_id() == session_id && session.room_id().eq(&room_id)
+                })
+                .await
+                .map_err(into_err)?,
+        )
+        .map_err(into_err)
     }
 
     /// Get the number of backed up room keys and the total number of room keys.

--- a/src/machine.rs
+++ b/src/machine.rs
@@ -605,9 +605,9 @@ impl OlmMachine {
     /// Export room keys in unencrypted format for a given session_id. This currently exports a 
     /// json blob.
     #[napi]
-    pub async fn export_room_keys_for_session(&self, session_id: String) -> napi::Result<String> {
+    pub async fn export_room_keys_for_session(&self, room_id: String, session_id: String) -> napi::Result<String> {
         serde_json::to_string(
-            &self.inner.export_room_keys(|session| session.session_id() == session_id)
+            &self.inner.export_room_keys(|session| session.session_id() == session_id && session.room_id().eq(&room_id))
             .await.map_err(into_err)?
         ).map_err(into_err)
     }

--- a/src/machine.rs
+++ b/src/machine.rs
@@ -602,6 +602,16 @@ impl OlmMachine {
         }
     }
 
+    /// Export room keys in unencrypted format for a given session_id. This currently exports a 
+    /// json blob.
+    #[napi]
+    pub async fn export_room_keys_for_session(&self, session_id: String) -> napi::Result<String> {
+        serde_json::to_string(
+            &self.inner.export_room_keys(|session| session.session_id() == session_id)
+            .await.map_err(into_err)?
+        ).map_err(into_err)
+    }
+
     /// Get the number of backed up room keys and the total number of room keys.
     #[napi]
     pub async fn room_key_counts(&self) -> napi::Result<RoomKeyCounts> {


### PR DESCRIPTION
This allows us to selectively export a session's room keys without having to pull the whole lot. We might want to do better typing though.