### PR TITLE
v0.1.0-beta.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Matrix-Rust-SDK Node.js Bindings
 
+## 0.1.0-beta.11 - 2023-09-05
+
+-   Add `export_room_keys_for_session`. [#26](https://github.com/matrix-org/matrix-rust-sdk-crypto-nodejs/pull/26)
+
 ## 0.1.0-beta.10 - 2023-08-11
 
 -   Return `ToDeviceRequest` objects from `OlmMachine.share_room_key`. [#15](https://github.com/matrix-org/matrix-rust-sdk-crypto-nodejs/pull/15)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@matrix-org/matrix-sdk-crypto-nodejs",
-    "version": "0.1.0-beta.10",
+    "version": "0.1.0-beta.11",
     "main": "index.js",
     "types": "index.d.ts",
     "napi": {


### PR DESCRIPTION
This is for getting https://github.com/matrix-org/matrix-rust-sdk-crypto-nodejs/pull/26 into a release.