### PR TITLE
Adds prebuilt library support for s390x

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,7 @@ env:
   CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: 'aarch64-linux-gnu-gcc'
   CARGO_TARGET_I686_UNKNOWN_LINUX_GNU_LINKER: 'i686-linux-gnu-gcc'
   CARGO_TARGET_ARM_UNKNOWN_LINUX_GNUEABIHF_LINKER: 'arm-linux-gnueabihf-gcc'
+  CARGO_TARGET_S390X_UNKNOWN_LINUX_GNU_LINKER: 's390x-linux-gnu-gcc'
 
 on:
   push:
@@ -53,6 +54,9 @@ jobs:
           - target: x86_64-unknown-linux-musl
             os: ubuntu-20.04
             apt_install: musl-tools
+          - target: s390x-unknown-linux-gnu
+            os: ubuntu-20.04
+            apt_install: gcc-s390x-linux-gnu g++-s390x-linux-gnu
           # ----------------------------------- macOS
           - target: aarch64-apple-darwin
             os: macos-latest

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ When installing, NPM will download the corresponding prebuilt Rust library for y
   </thead>
   <tbody>
     <tr>
-      <td rowspan="5">Linux</td>
+      <td rowspan="6">Linux</td>
       <td rowspan="2"><code>aarch</code></td>
       <td><code>aarch64-unknown-linux-gnu</code></td>
       <td>✅</td>
@@ -50,6 +50,11 @@ When installing, NPM will download the corresponding prebuilt Rust library for y
     </tr>
     <tr>
       <td><code>i686-unknown-linux-gnu</code></td>
+      <td>✅</td>
+    </tr>
+    <tr>
+      <td rowspan="1"><code>s390x</code></td>
+      <td><code>s390x-unknown-linux-gnu</code></td>
       <td>✅</td>
     </tr>
     <tr>

--- a/download-lib.js
+++ b/download-lib.js
@@ -116,6 +116,9 @@ switch (platform) {
             case "arm":
                 download_lib("matrix-sdk-crypto.linux-arm-gnueabihf.node");
                 break;
+            case "s390x":
+                download_lib("matrix-sdk-crypto.linux-s390x-gnu.node");
+                break;
             default:
                 throw new Error(`Unsupported architecture on Linux: ${arch}`);
         }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     },
     "license": "Apache-2.0",
     "devDependencies": {
-        "@napi-rs/cli": "^2.9.0",
+        "@napi-rs/cli": "^2.18.0",
         "jest": "^28.1.0",
         "prettier": "^2.8.3",
         "typedoc": "^0.22.17",


### PR DESCRIPTION
This PR addresses the issue https://github.com/matrix-org/matrix-rust-sdk-crypto-nodejs/issues/24 by updating the release workflow to include an additional cross-compilation target and extending the `download-lib.js` file to handle this new architecture.