### PR TITLE
v0.2.0-beta.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Matrix-Rust-SDK Node.js Bindings
 
+## 0.2.0-beta.1 - 2024-06-11
+
+-   Support Node.JS 22, drop support for 16, 19.
+-   Update matrix-rust-sdk dependency.
+-   `RoomId` no longer has a `localpart` property.
+
 ## 0.1.0-beta.12 - 2024-02-01
 
 -   Add prebuilt library support for 390x. [#32](https://github.com/matrix-org/matrix-rust-sdk-crypto-nodejs/pull/32)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@matrix-org/matrix-sdk-crypto-nodejs",
-    "version": "0.1.0-beta.12",
+    "version": "0.2.0-beta.1",
     "main": "index.js",
     "types": "index.d.ts",
     "napi": {


### PR DESCRIPTION
Bumped the version because we're no longer supporting Node 16,19 but since we're still in a beta world, I've not increased the major version.