### PR TITLE
Don't validate room ID server names for v12 compat

### DIFF
--- a/src/identifiers.rs
+++ b/src/identifiers.rs
@@ -210,12 +210,7 @@ impl RoomId {
     #[napi(constructor, strict)]
     pub fn new(id: String) -> napi::Result<Self> {
         let room_id = ruma::RoomId::parse(id).map_err(into_err)?;
-        match room_id.server_name() {
-            Some(_) => Ok(Self::from(room_id)),
-            None => Err(napi::Error::from_reason(
-                "Room ID does not have a valid server_name".to_owned(),
-            )),
-        }
+        Ok(Self::from(room_id))
     }
 
     /// Return the room ID as a string.
@@ -228,7 +223,7 @@ impl RoomId {
     /// Returns the server name of the room ID.
     #[napi(getter)]
     pub fn server_name(&self) -> ServerName {
-        ServerName { inner: self.inner.server_name().unwrap().to_owned() }
+        ServerName { inner: self.inner.server_name().unwrap_or(<&ruma::ServerName>::try_from("").unwrap()).to_owned() }
     }
 }
 


### PR DESCRIPTION
This is a kludge to remove server name validation on room IDs, so as to allow usage of v12-style room IDs (which lack a server name component).

The correct fix is to update `matrix-sdk` to at least https://github.com/matrix-org/matrix-rust-sdk/commit/0e622cc5a1f1039e4680136cf15d7db1418adcf7, but that brings in a slew of breaking changes.