### PR TITLE
Update to Ubuntu 22.04 as minimum supported version (glibc 2.35)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,10 +53,10 @@ jobs:
       fail-fast: true
       matrix:
         # Use Ubuntu LTS-1 for broader glibc compatibility.
-        os: [ubuntu-20.04]
+        os: [ubuntu-22.04]
         node-version: [18.0, 20.0, 22.0]
         include:
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             os-name: 🐧
 
           - os: macos-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,21 +41,21 @@ jobs:
           # ----------------------------------- Linux
           # Use Ubuntu LTS-1 for broader glibc compatibility.
           - target: x86_64-unknown-linux-gnu
-            os: ubuntu-20.04
+            os: ubuntu-22.04
           - target: i686-unknown-linux-gnu
             apt_install: gcc-i686-linux-gnu g++-i686-linux-gnu
-            os: ubuntu-20.04
+            os: ubuntu-22.04
           - target: aarch64-unknown-linux-gnu
-            os: ubuntu-20.04
+            os: ubuntu-22.04
             apt_install: gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
           - target: arm-unknown-linux-gnueabihf
-            os: ubuntu-20.04
+            os: ubuntu-22.04
             apt_install: gcc-arm-linux-gnueabihf
           - target: x86_64-unknown-linux-musl
-            os: ubuntu-20.04
+            os: ubuntu-22.04
             apt_install: musl-tools
           - target: s390x-unknown-linux-gnu
-            os: ubuntu-20.04
+            os: ubuntu-22.04
             apt_install: gcc-s390x-linux-gnu g++-s390x-linux-gnu
           # ----------------------------------- macOS
           - target: aarch64-apple-darwin

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ## Next release
 
- - Update matrix-rust-sdk dependency to 0.9.0.# Matrix-Rust-SDK Node.js Bindings
- - Minimum supported glibc version is now `2.35` (Ubuntu 22.04+ compatible). Support has been dropped for prior versions.
+-   Update matrix-rust-sdk dependency to 0.9.0.# Matrix-Rust-SDK Node.js Bindings
+-   Minimum supported glibc version is now `2.35` (Ubuntu 22.04+ compatible). Support has been dropped for prior versions.
 
 
 ## 0.3.0-beta.1 - 2024-11-18

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,6 @@
 -   Update matrix-rust-sdk dependency to 0.9.0.
 -   Minimum supported glibc version is now `2.35` (Ubuntu 22.04+ compatible). Support has been dropped for prior versions.
 
-
 ## 0.3.0-beta.1 - 2024-11-18
 
 -   Update matrix-rust-sdk dependency.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Next release
 
--   Update matrix-rust-sdk dependency to 0.9.0.# Matrix-Rust-SDK Node.js Bindings
+-   Update matrix-rust-sdk dependency to 0.9.0.
 -   Minimum supported glibc version is now `2.35` (Ubuntu 22.04+ compatible). Support has been dropped for prior versions.
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## Next release
 
--   Update matrix-rust-sdk dependency to 0.9.0.
+ - Update matrix-rust-sdk dependency to 0.9.0.# Matrix-Rust-SDK Node.js Bindings
+ - Minimum supported glibc version is now `2.35` (Ubuntu 22.04+ compatible). Support has been dropped for prior versions.
+
 
 ## 0.3.0-beta.1 - 2024-11-18
 


### PR DESCRIPTION
As 20.04 is long out of support and not supported in CI either. The reason for sticking to an Ubuntu version is the glibc version built against iirc, so let's call that out.