### PR TITLE
Release v0.4.0 beta.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Matrix-Rust-SDK Node.js Bindings
 
-## Next release
+## v0.4.0-beta.1 - 2025-08-11
 
 -   Update matrix-rust-sdk dependency to 0.9.0.
 -   Support Node.JS 24, drop support for 18, 20.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@matrix-org/matrix-sdk-crypto-nodejs",
-    "version": "0.3.0-beta.1",
+    "version": "0.4.0-beta.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@matrix-org/matrix-sdk-crypto-nodejs",
-            "version": "0.3.0-beta.1",
+            "version": "0.4.0-beta.1",
             "hasInstallScript": true,
             "license": "Apache-2.0",
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@matrix-org/matrix-sdk-crypto-nodejs",
-    "version": "0.3.0-beta.1",
+    "version": "0.4.0-beta.1",
     "main": "index.js",
     "types": "index.d.ts",
     "napi": {


### PR DESCRIPTION
Messed up [last time](https://github.com/matrix-org/matrix-rust-sdk-crypto-nodejs/pull/51) by squash-merging the PR, and by merging it before pushing the tag to trigger the release workflow.  Trying it again.