### PR TITLE
Release v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## UNRELEASED
 
+## v0.4.0 - 2026-01-08
+
 -   Fix malformed `/keys/upload`, `/keys/query` and `/keys/claim` requests. [#56](https://github.com/matrix-org/matrix-rust-sdk-crypto-nodejs/pull/56)
 
 ## v0.4.0-beta.1 - 2025-08-11

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@matrix-org/matrix-sdk-crypto-nodejs",
-    "version": "0.4.0-beta.1",
+    "version": "0.4.0",
     "main": "index.js",
     "types": "index.d.ts",
     "napi": {


### PR DESCRIPTION
Cutting a release to include #56.

I'm removing the "beta" label from the version number: empirically, this project is being used widely enough that bugs in it are sufficient to prevent Synapse from following the spec, so I don't think the "beta" label is meaningful.