### PR TITLE
Harden CI with pinned action versions and Zizmor analysis

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,7 @@
 name: CI
 
+permissions: {}
+
 on:
   push:
     branches: [main]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
       - name: Checkout the repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@nightly
@@ -37,7 +37,7 @@ jobs:
           cargo fmt -- --check
 
       - name: Install Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version-file: .node-version
 
@@ -70,18 +70,18 @@ jobs:
 
     steps:
       - name: Checkout the repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
 
       - name: Load cache
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
         with:
           save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Install Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: ${{ matrix.node-version }}
 
@@ -101,7 +101,7 @@ jobs:
           cp *.node release-mode-lib.node
           npm run build
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         if: failure()
         with:
           name: Failure Files
@@ -124,10 +124,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install Protoc
-        uses: arduino/setup-protoc@v1
+        uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3.0.0
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -135,12 +135,12 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Install Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version-file: .node-version
 
       - name: Load cache
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
         with:
           save-if: ${{ github.ref == 'refs/heads/main' }}
 
@@ -151,11 +151,11 @@ jobs:
 
       - name: Upload artifact
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4.0.0
         with:
           path: './docs/'
 
       - name: Deploy to GitHub Pages
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         id: deployment
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,9 +30,10 @@ jobs:
           persist-credentials: false
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@nightly
-        with:
-          components: rustfmt
+        run: |
+          rustup install nightly
+          rustup default nightly
+          rustup component add rustfmt
 
       - name: Check formatting
         run: |
@@ -77,7 +78,9 @@ jobs:
           persist-credentials: false
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        run: |
+          rustup install stable
+          rustup default stable
 
       - name: Load cache
         uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
@@ -138,7 +141,9 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        run: |
+          rustup install stable
+          rustup default stable
 
       - name: Install Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,8 @@ jobs:
     steps:
       - name: Checkout the repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@nightly
@@ -71,6 +73,8 @@ jobs:
     steps:
       - name: Checkout the repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
@@ -125,6 +129,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Install Protoc
         uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3.0.0

--- a/.github/workflows/prep-release.yml
+++ b/.github/workflows/prep-release.yml
@@ -84,28 +84,22 @@ jobs:
       # if we have generated changes
       - name: Update Github Release notes
         if: inputs.previous_version
-        uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2.5.0
-        with:
-          draft: true
-          tag_name: "v${{ inputs.version }}"
-          body_path: "CHANGES-${{ inputs.version }}.md"
+        run: gh release create "v${INPUTS_VERSION}" --draft --notes-file "CHANGES-${INPUTS_VERSION}.md"
+        env:
+          INPUTS_VERSION: ${{ inputs.version }}
 
       # no changes, use the default changelog for the body
       - name: Update Github Release notes
         if: "!inputs.previous_version"
-        uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2.5.0
-        with:
-          draft: true
-          tag_name: "v${{ inputs.version }}"
-          body_path: "CHANGELOG.md"
+        run: gh release create "v${INPUTS_VERSION}" --draft --notes-file "CHANGELOG.md"
+        env:
+          INPUTS_VERSION: ${{ inputs.version }}
 
       # let's create a PR for all this, too
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@c0f553fe549906ede9cf27b5156039d195d2ece0 # v8.1.0
-        with:
-          title: "Preparing Release v${{ inputs.version }}"
-          body: |
-            Automatic Pull-Request to merge release v${{ inputs.version }}
+        run: gh pr create --title "Preparing Release v${INPUTS_VERSION}" --body "Automatic Pull-Request to merge release v${INPUTS_VERSION}" --base main --head "gh-action/release-v${INPUTS_VERSION}"
+        env:
+          INPUTS_VERSION: ${{ inputs.version }}
 
   trigger-release:
     # and trigger the tagging release workflow

--- a/.github/workflows/prep-release.yml
+++ b/.github/workflows/prep-release.yml
@@ -19,6 +19,8 @@ name: Prepare Crypto-Node.js Release
 #
 #  The remaining tasks are done by the `release` workflow.
 
+permissions: {}
+
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/prep-release.yml
+++ b/.github/workflows/prep-release.yml
@@ -38,6 +38,8 @@ jobs:
       tag: "v${{ inputs.version }}"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
 
       # Generate changelog since last tag, if given

--- a/.github/workflows/prep-release.yml
+++ b/.github/workflows/prep-release.yml
@@ -66,7 +66,9 @@ jobs:
 
       - name: Set version
         id: package_version
-        run: npm version ${{ inputs.version }}
+        run: npm version ${INPUTS_VERSION}
+        env:
+          INPUTS_VERSION: ${{ inputs.version }}
 
       - uses: EndBug/add-and-commit@a94899bca583c204427a224a7af87c02f9b325d5 # v9.1.4
         with:

--- a/.github/workflows/prep-release.yml
+++ b/.github/workflows/prep-release.yml
@@ -37,13 +37,13 @@ jobs:
     outputs:
       tag: "v${{ inputs.version }}"
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
 
       # Generate changelog since last tag, if given
       - name: Generate a changelog for upload
         if: inputs.previous_version
-        uses: orhun/git-cliff-action@v1
+        uses: orhun/git-cliff-action@c93ef52f3d0ddcdcc9bd5447d98d458a11cd4f72 # v4.7.1
         with:
           config: "cliff.toml"
           args: --strip header "v${{ inputs.previous_version }}..HEAD"
@@ -54,7 +54,7 @@ jobs:
       # Update changelog since last tag, if given
       - name: Update existing Changelog
         if: inputs.previous_version
-        uses: orhun/git-cliff-action@v1
+        uses: orhun/git-cliff-action@c93ef52f3d0ddcdcc9bd5447d98d458a11cd4f72 # v4.7.1
         with:
           config: "cliff.toml"
           args: "v${{ inputs.previous_version }}..HEAD"
@@ -66,7 +66,7 @@ jobs:
         id: package_version
         run: npm version ${{ inputs.version }}
 
-      - uses: EndBug/add-and-commit@v9
+      - uses: EndBug/add-and-commit@a94899bca583c204427a224a7af87c02f9b325d5 # v9.1.4
         with:
           default_author: github_actions
           message: "Tagging Crypto-Node.js for release"
@@ -80,7 +80,7 @@ jobs:
       # if we have generated changes
       - name: Update Github Release notes
         if: inputs.previous_version
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2.5.0
         with:
           draft: true
           tag_name: "v${{ inputs.version }}"
@@ -89,7 +89,7 @@ jobs:
       # no changes, use the default changelog for the body
       - name: Update Github Release notes
         if: "!inputs.previous_version"
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2.5.0
         with:
           draft: true
           tag_name: "v${{ inputs.version }}"
@@ -97,7 +97,7 @@ jobs:
 
       # let's create a PR for all this, too
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v4
+        uses: peter-evans/create-pull-request@c0f553fe549906ede9cf27b5156039d195d2ece0 # v8.1.0
         with:
           title: "Preparing Release v${{ inputs.version }}"
           body: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -123,10 +123,10 @@ jobs:
           npm install --ignore-scripts
           npx napi build --platform --release --strip --target ${{ matrix.target }} ${{ contains(matrix.target, 'musl') && '--zig' || '' }}
       - name: Upload artifacts to release
-        uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2.5.0
-        with:
-          draft: true
-          files: "*.node"
+        run: |
+          gh release upload "$INPUTS_TAG" "*.node" --draft
+        environment:
+          INPUTS_TAG: ${{ inputs.tag }}
 
   publish-nodejs-package:
     name: "Package nodejs package"
@@ -170,7 +170,8 @@ jobs:
           npm run release-build
           npm pack
       - name: Upload npm package to release
-        run: gh release upload ${INPUTS_TAG} "*.tgz" --draft
+        run: |
+          gh release upload "${INPUTS_TAG}" "*.tgz" --draft
         env:
           INPUTS_TAG: ${{ inputs.tag }}
       - name: Publish to npmjs.com

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,9 +87,11 @@ jobs:
         with:
           persist-credentials: false
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@nightly
-        with:
-          targets: ${{ matrix.target }}
+        run: |
+          rustup install nightly
+          rustup default nightly
+          rustup component add rustfmt
+          rustup target add ${{ matrix.target }} --toolchain nightly
       - name: Install Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
       # Zig is needed on musl targets for reliable linking. In napi V3 this moves from the --zig flag to the --cross-compile flag.
@@ -142,7 +144,10 @@ jobs:
         with:
           persist-credentials: false
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@nightly
+        run: |
+          rustup install nightly
+          rustup default nightly
+          rustup component add rustfmt
       - name: Install Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -170,9 +170,8 @@ jobs:
           npm run release-build
           npm pack
       - name: Upload npm package to release
-        uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2.5.0
-        with:
-          draft: true
-          files: "*.tgz"
+        run: gh release upload ${INPUTS_TAG} "*.tgz" --draft
+        env:
+          INPUTS_TAG: ${{ inputs.tag }}
       - name: Publish to npmjs.com
         run: npm publish --access public --provenance

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,9 +80,12 @@ jobs:
         if: "${{ inputs.tag }}"
         with:
           ref: ${{ inputs.tag }}
+          persist-credentials: false
       # use the default
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         if: "${{ !inputs.tag }}"
+        with:
+          persist-credentials: false
       - name: Install Rust
         uses: dtolnay/rust-toolchain@nightly
         with:
@@ -132,9 +135,12 @@ jobs:
         if: "${{ inputs.tag }}"
         with:
           ref: ${{ inputs.tag }}
+          persist-credentials: false
       # use the default
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         if: "${{ !inputs.tag }}"
+        with:
+          persist-credentials: false
       - name: Install Rust
         uses: dtolnay/rust-toolchain@nightly
       - name: Install Node.js

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,6 +94,9 @@ jobs:
           rustup target add ${{ matrix.target }} --toolchain nightly
       - name: Install Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          cache: ""
+          package-manager-cache: false
       # Zig is needed on musl targets for reliable linking. In napi V3 this moves from the --zig flag to the --cross-compile flag.
       # See: https://napi.rs/docs/cross-build
       # See: https://github.com/napi-rs/callback-example/blob/15855ea37f668df91d24124142895addd33e468f/.github/workflows/CI.yml#L115
@@ -101,6 +104,7 @@ jobs:
         if: ${{ contains(matrix.target, 'musl') }}
         with:
           version: 0.14.1
+          use-cache: false
       - name: Install cargo-zigbuild
         uses: taiki-e/install-action@a37010ded18ff788be4440302bd6830b1ae50d8b # v2.68.25
         if: ${{ contains(matrix.target, 'musl') }}
@@ -108,6 +112,8 @@ jobs:
           tool: cargo-zigbuild
       - name: Load cache
         uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
+        with:
+          lookup-only: true
       - if: ${{ matrix.apt_install }}
         run: |
           sudo apt-get update
@@ -154,6 +160,8 @@ jobs:
           node-version: 22
           registry-url: https://registry.npmjs.org/
           scope: '@matrix-org'
+          cache: ""
+          package-manager-cache: false
       - name: Upgrade npm for Trusted Publishing
         run: npm i -g npm@latest
       - name: Build lib

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,34 +75,34 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       # use the given tag
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         name: "Checking out ${{ inputs.tag }}"
         if: "${{ inputs.tag }}"
         with:
           ref: ${{ inputs.tag }}
       # use the default
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         if: "${{ !inputs.tag }}"
       - name: Install Rust
         uses: dtolnay/rust-toolchain@nightly
         with:
           targets: ${{ matrix.target }}
       - name: Install Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
       # Zig is needed on musl targets for reliable linking. In napi V3 this moves from the --zig flag to the --cross-compile flag.
       # See: https://napi.rs/docs/cross-build
       # See: https://github.com/napi-rs/callback-example/blob/15855ea37f668df91d24124142895addd33e468f/.github/workflows/CI.yml#L115
-      - uses: mlugg/setup-zig@v2
+      - uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2.2.1
         if: ${{ contains(matrix.target, 'musl') }}
         with:
           version: 0.14.1
       - name: Install cargo-zigbuild
-        uses: taiki-e/install-action@v2
+        uses: taiki-e/install-action@a37010ded18ff788be4440302bd6830b1ae50d8b # v2.68.25
         if: ${{ contains(matrix.target, 'musl') }}
         with:
           tool: cargo-zigbuild
       - name: Load cache
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
       - if: ${{ matrix.apt_install }}
         run: |
           sudo apt-get update
@@ -112,7 +112,7 @@ jobs:
           npm install --ignore-scripts
           npx napi build --platform --release --strip --target ${{ matrix.target }} ${{ contains(matrix.target, 'musl') && '--zig' || '' }}
       - name: Upload artifacts to release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2.5.0
         with:
           draft: true
           files: "*.node"
@@ -127,18 +127,18 @@ jobs:
       id-token: write
     steps:
       # use the given tag
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         name: "Checking out ${{ inputs.tag }}"
         if: "${{ inputs.tag }}"
         with:
           ref: ${{ inputs.tag }}
       # use the default
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         if: "${{ !inputs.tag }}"
       - name: Install Rust
         uses: dtolnay/rust-toolchain@nightly
       - name: Install Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: 22
           registry-url: https://registry.npmjs.org/
@@ -151,7 +151,7 @@ jobs:
           npm run release-build
           npm pack
       - name: Upload npm package to release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2.5.0
         with:
           draft: true
           files: "*.tgz"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,8 @@ name: Release Crypto-Node.js
 # The usual way to trigger this is by manually triggering the `prep-release`
 # workflow. See its documentation for instructions how to use it.
 
+permissions: {}
+
 env:
   CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: 'aarch64-linux-gnu-gcc'
   CARGO_TARGET_I686_UNKNOWN_LINUX_GNU_LINKER: 'i686-linux-gnu-gcc'

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,25 @@
+name: Analyse workflows with zizmor
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["**"]
+
+permissions: {}
+
+jobs:
+  zizmor:
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      contents: read
+      actions: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@71321a20a9ded102f6e9ce5718a2fcec2c4f70d8 # v0.5.2


### PR DESCRIPTION
This PR hardens the various CI workflows in the repo.

- Updates actions to latest available versions, since many were a few years out of date.
- Disables credential persistence by `actions/checkout`, since we don't do any pushing back to the remote.
- ⚠️ Disables caching for the release workflow.
- Uses the `gh` CLI in place of third-party actions. 

Fixes https://github.com/matrix-org/matrix-rust-sdk-crypto-nodejs/issues/65