### PR TITLE
Fix environment setting in release workflow job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -127,7 +127,7 @@ jobs:
       - name: Upload artifacts to release
         run: |
           gh release upload "$INPUTS_TAG" "*.node" --draft
-        environment:
+        env:
           INPUTS_TAG: ${{ inputs.tag }}
 
   publish-nodejs-package:


### PR DESCRIPTION
The correct setting is "env", not "environment".
See https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#jobsjob_idstepsenv