### PR TITLE
Allow configurable MATRIX_SDK_CRYPTO_DOWNLOADS_BASE_URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ corporate network or a region with restricted access to GitHub), set the
 `npm install`:
 
 ```sh
-$ export MATRIX_SDK_CRYPTO_DOWNLOADS_BASE_URL="https://your-mirror.example.com/matrix-rust-sdk-crypto-nodejs/releases/download"
+$ export MATRIX_SDK_CRYPTO_DOWNLOADS_BASE_URL="https://npmmirror.com/mirrors/@matrix-org/matrix-sdk-crypto-nodejs"
 $ npm install --save @matrix-org/matrix-sdk-crypto-nodejs
 ```
 

--- a/README.md
+++ b/README.md
@@ -86,6 +86,23 @@ When installing, NPM will download the corresponding prebuilt Rust library for y
   </tbody>
 </table>
 
+### Custom downloads base URL
+
+By default, prebuilt binaries are downloaded from
+`https://github.com/matrix-org/matrix-rust-sdk-crypto-nodejs/releases/download`.
+If you need to fetch them from a mirror or a private host (for example, in a
+corporate network or a region with restricted access to GitHub), set the
+`MATRIX_SDK_CRYPTO_DOWNLOADS_BASE_URL` environment variable before running
+`npm install`:
+
+```sh
+$ export MATRIX_SDK_CRYPTO_DOWNLOADS_BASE_URL="https://your-mirror.example.com/matrix-rust-sdk-crypto-nodejs/releases/download"
+$ npm install --save @matrix-org/matrix-sdk-crypto-nodejs
+```
+
+The downloader appends `/v<version>/<filename>` to this base URL, so the mirror
+must preserve the same directory layout as the GitHub Releases page.
+
 ## Development
 
 This Node.js binding is written in [Rust]. To build this binding, you

--- a/download-lib.js
+++ b/download-lib.js
@@ -7,7 +7,7 @@ const { version } = require("./package.json");
 const platform = process.env.npm_config_target_platform || process.env.npm_config_platform || process.platform;
 const arch = process.env.npm_config_target_arch || process.env.npm_config_arch || process.arch;
 
-const DOWNLOADS_BASE_URL = process.env.DOWNLOADS_BASE_URL || "https://github.com/matrix-org/matrix-rust-sdk-crypto-nodejs/releases/download";
+const DOWNLOADS_BASE_URL = process.env.MATRIX_SDK_CRYPTO_DOWNLOADS_BASE_URL || "https://github.com/matrix-org/matrix-rust-sdk-crypto-nodejs/releases/download";
 const CURRENT_VERSION = `v${version}`;
 
 const byteHelper = function (value) {

--- a/download-lib.js
+++ b/download-lib.js
@@ -7,7 +7,7 @@ const { version } = require("./package.json");
 const platform = process.env.npm_config_target_platform || process.env.npm_config_platform || process.platform;
 const arch = process.env.npm_config_target_arch || process.env.npm_config_arch || process.arch;
 
-const DOWNLOADS_BASE_URL = "https://github.com/matrix-org/matrix-rust-sdk-crypto-nodejs/releases/download";
+const DOWNLOADS_BASE_URL = process.env.DOWNLOADS_BASE_URL || "https://github.com/matrix-org/matrix-rust-sdk-crypto-nodejs/releases/download";
 const CURRENT_VERSION = `v${version}`;
 
 const byteHelper = function (value) {

--- a/download-lib.js
+++ b/download-lib.js
@@ -7,7 +7,9 @@ const { version } = require("./package.json");
 const platform = process.env.npm_config_target_platform || process.env.npm_config_platform || process.platform;
 const arch = process.env.npm_config_target_arch || process.env.npm_config_arch || process.arch;
 
-const DOWNLOADS_BASE_URL = process.env.MATRIX_SDK_CRYPTO_DOWNLOADS_BASE_URL || "https://github.com/matrix-org/matrix-rust-sdk-crypto-nodejs/releases/download";
+const DOWNLOADS_BASE_URL =
+    process.env.MATRIX_SDK_CRYPTO_DOWNLOADS_BASE_URL ||
+    "https://github.com/matrix-org/matrix-rust-sdk-crypto-nodejs/releases/download";
 const CURRENT_VERSION = `v${version}`;
 
 const byteHelper = function (value) {


### PR DESCRIPTION
Give users the opportunity to use a custom download address to replace the GitHub address to prevent the problem of slow network access to GitHub.
