### PR TITLE
Remove nonexistent "--draft" argument from "gh release upload" command

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -126,7 +126,7 @@ jobs:
           npx napi build --platform --release --strip --target ${{ matrix.target }} ${{ contains(matrix.target, 'musl') && '--zig' || '' }}
       - name: Upload artifacts to release
         run: |
-          gh release upload "$INPUTS_TAG" "*.node" --draft
+          gh release upload "$INPUTS_TAG" "*.node"
         env:
           INPUTS_TAG: ${{ inputs.tag }}
 
@@ -173,7 +173,7 @@ jobs:
           npm pack
       - name: Upload npm package to release
         run: |
-          gh release upload "${INPUTS_TAG}" "*.tgz" --draft
+          gh release upload "${INPUTS_TAG}" "*.tgz"
         env:
           INPUTS_TAG: ${{ inputs.tag }}
       - name: Publish to npmjs.com

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## UNRELEASED
 
+-   Try to fix release process.
+
 ## v0.5.0 - 2026-04-20
 
 -   Support Node.JS 25, drop support for 22. [#68](https://github.com/matrix-org/matrix-rust-sdk-crypto-nodejs/pull/68)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## UNRELEASED
 
--   Try to fix release process.
+-   Try to fix release script. [#72](https://github.com/matrix-org/matrix-rust-sdk-crypto-nodejs/pull/72)
 
 ## v0.5.0 - 2026-04-20
 


### PR DESCRIPTION
The `--draft` argument was probably copy-and-pasted from a `gh release create` command, but that argument does not exist on `gh release upload`.

Hopefully this works. :crossed_fingers: 