### PR TITLE
Update package version in lockfile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,10 @@ jobs:
       - name: run lint
         run: npm run lint
 
+      - name: Check package version consistency
+        run: |
+          diff <(jq .version package.json) <(jq .version package-lock.json)
+
   test:
     name: test ${{ matrix.os-name }}, v${{ matrix.node-version }}
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,7 @@ jobs:
       - name: Check package version consistency
         run: |
           diff <(jq .version package.json) <(jq .version package-lock.json)
+          diff <(jq .version package.json) <(jq '.packages[""].version' package-lock.json)
 
   test:
     name: test ${{ matrix.os-name }}, v${{ matrix.node-version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,10 +52,8 @@ jobs:
       - name: run lint
         run: npm run lint
 
-      - name: Check package version consistency
-        run: |
-          diff <(jq .version package.json) <(jq .version package-lock.json)
-          diff <(jq .version package.json) <(jq '.packages[""].version' package-lock.json)
+      - name: Check for clean workspace after package installation
+        run: git diff --exit-code
 
   test:
     name: test ${{ matrix.os-name }}, v${{ matrix.node-version }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@matrix-org/matrix-sdk-crypto-nodejs",
-    "version": "0.4.0",
+    "version": "0.5.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
     "packages": {
         "": {
             "name": "@matrix-org/matrix-sdk-crypto-nodejs",
-            "version": "0.4.0",
+            "version": "0.5.0",
             "hasInstallScript": true,
             "license": "Apache-2.0",
             "dependencies": {


### PR DESCRIPTION
Every now and then (not only for this repo), a release gets cut where the version got updated in `package.json` but not in the lockfile.  This PR updates the lockfile with the correct version, and adds a CI check to prevent such a mismatch from happening again.