### PR TITLE
Release v0.5.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -128,7 +128,7 @@ jobs:
           npx napi build --platform --release --strip --target ${{ matrix.target }} ${{ contains(matrix.target, 'musl') && '--zig' || '' }}
       - name: Upload artifacts to release
         run: |
-          gh release upload "$INPUTS_TAG" "*.node"
+          gh release create "$INPUTS_TAG" "*.node"
         env:
           INPUTS_TAG: ${{ inputs.tag || github.ref_name }}
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,8 +37,22 @@ on:
         type: string
 
 jobs:
+  draft-release:
+    name: Create draft release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Create draft release
+        run: gh release create "$INPUTS_TAG" --draft
+        env:
+          INPUTS_TAG: ${{ inputs.tag || github.ref_name }}
+          GH_TOKEN: ${{ github.token }}
+
   upload-assets:
     name: "Upload prebuilt libraries"
+    needs:
+      - draft-release
     permissions:
       contents: write
     strategy:
@@ -128,7 +142,7 @@ jobs:
           npx napi build --platform --release --strip --target ${{ matrix.target }} ${{ contains(matrix.target, 'musl') && '--zig' || '' }}
       - name: Upload artifacts to release
         run: |
-          gh release create "$INPUTS_TAG" "*.node"
+          gh release upload "$INPUTS_TAG" "*.node"
         env:
           INPUTS_TAG: ${{ inputs.tag || github.ref_name }}
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -131,6 +131,7 @@ jobs:
           gh release upload "$INPUTS_TAG" "*.node"
         env:
           INPUTS_TAG: ${{ inputs.tag }}
+          GH_TOKEN: ${{ github.token }}
 
   publish-nodejs-package:
     name: "Package nodejs package"
@@ -178,5 +179,6 @@ jobs:
           gh release upload "${INPUTS_TAG}" "*.tgz"
         env:
           INPUTS_TAG: ${{ inputs.tag }}
+          GH_TOKEN: ${{ github.token }}
       - name: Publish to npmjs.com
         run: npm publish --access public --provenance

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -130,7 +130,7 @@ jobs:
         run: |
           gh release upload "$INPUTS_TAG" "*.node"
         env:
-          INPUTS_TAG: ${{ inputs.tag }}
+          INPUTS_TAG: ${{ inputs.tag || github.ref_name }}
           GH_TOKEN: ${{ github.token }}
 
   publish-nodejs-package:
@@ -178,7 +178,7 @@ jobs:
         run: |
           gh release upload "${INPUTS_TAG}" "*.tgz"
         env:
-          INPUTS_TAG: ${{ inputs.tag }}
+          INPUTS_TAG: ${{ inputs.tag || github.ref_name }}
           GH_TOKEN: ${{ github.token }}
       - name: Publish to npmjs.com
         run: npm publish --access public --provenance

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -162,7 +162,7 @@ jobs:
       - name: Upload artifacts to release (Windows)
         if: runner.os == 'Windows'
         run: |
-          gh release upload "env:$INPUTS_TAG" "*.node"
+          gh release upload "$env:INPUTS_TAG" "*.node"
         env:
           INPUTS_TAG: ${{ inputs.tag || github.ref_name }}
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,6 +43,18 @@ jobs:
     permissions:
       contents: write
     steps:
+      # use the given tag
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        name: "Checking out ${{ inputs.tag }}"
+        if: "${{ inputs.tag }}"
+        with:
+          ref: ${{ inputs.tag }}
+          persist-credentials: false
+      # use the default
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        if: "${{ !inputs.tag }}"
+        with:
+          persist-credentials: false
       - name: Create draft release
         run: gh release create "$INPUTS_TAG" --draft
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -141,7 +141,7 @@ jobs:
         with:
           tool: cargo-zigbuild
       - name: Load cache
-        uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           lookup-only: true
       - if: ${{ matrix.apt_install }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,7 +56,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Create draft release
-        run: gh release create "$INPUTS_TAG" --draft
+        run: gh release create "$INPUTS_TAG" --draft --title "$INPUTS_TAG" --generate-notes --verify-tag
         env:
           INPUTS_TAG: ${{ inputs.tag || github.ref_name }}
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -153,8 +153,16 @@ jobs:
           npm install --ignore-scripts
           npx napi build --platform --release --strip --target ${{ matrix.target }} ${{ contains(matrix.target, 'musl') && '--zig' || '' }}
       - name: Upload artifacts to release
+        if: runner.os != 'Windows'
         run: |
           gh release upload "$INPUTS_TAG" "*.node"
+        env:
+          INPUTS_TAG: ${{ inputs.tag || github.ref_name }}
+          GH_TOKEN: ${{ github.token }}
+      - name: Upload artifacts to release (Windows)
+        if: runner.os == 'Windows'
+        run: |
+          gh release upload "env:$INPUTS_TAG" "*.node"
         env:
           INPUTS_TAG: ${{ inputs.tag || github.ref_name }}
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,6 +39,8 @@ on:
 jobs:
   upload-assets:
     name: "Upload prebuilt libraries"
+    permissions:
+      contents: write
     strategy:
       fail-fast: false
       matrix:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## UNRELEASED
 
+## v0.5.1 - 2026-04-22
+
 -   Try to fix release script. [#72](https://github.com/matrix-org/matrix-rust-sdk-crypto-nodejs/pull/72)
 
 ## v0.5.0 - 2026-04-20

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@matrix-org/matrix-sdk-crypto-nodejs",
-    "version": "0.5.0",
+    "version": "0.5.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@matrix-org/matrix-sdk-crypto-nodejs",
-            "version": "0.5.0",
+            "version": "0.5.1",
             "hasInstallScript": true,
             "license": "Apache-2.0",
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@matrix-org/matrix-sdk-crypto-nodejs",
-    "version": "0.5.0",
+    "version": "0.5.1",
     "main": "index.js",
     "types": "index.d.ts",
     "repository": {


### PR DESCRIPTION
Continuation/retry of https://github.com/matrix-org/matrix-rust-sdk-crypto-nodejs/pull/74, which shouldn't have been merged before having pushed a release tag for it, as per the [release instructions](https://github.com/matrix-org/matrix-rust-sdk-crypto-nodejs/blob/main/RELEASING.md).