### PR TITLE
Support Node-API Version 8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## UNRELEASED
 
 -   Add support for Node.JS 26, and drop support for Node.JS 25. [#76](https://github.com/matrix-org/matrix-rust-sdk-crypto-nodejs/pull/76)
+-   Support Node-API Version 8. [#77](https://github.com/matrix-org/matrix-rust-sdk-crypto-nodejs/pull/77)
 
 ## v0.5.1 - 2026-04-22
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,8 +26,8 @@ tracing = ["dep:tracing-subscriber"]
 [dependencies]
 matrix-sdk-common = { version = "0.9.0", features = ["js"] }
 matrix-sdk-sqlite = { version = "0.9.0", features = ["crypto-store"] }
-napi = { version = "2.16.12", default-features = false, features = ["napi6", "tokio_rt"] }
-napi-derive = "2.16.12"
+napi = { version = "2.16.17", default-features = false, features = ["napi6", "tokio_rt"] }
+napi-derive = "2.16.13"
 ahash = "0.8.11"
 serde_json = "1.0.133"
 http = "1.1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ tracing = ["dep:tracing-subscriber"]
 [dependencies]
 matrix-sdk-common = { version = "0.9.0", features = ["js"] }
 matrix-sdk-sqlite = { version = "0.9.0", features = ["crypto-store"] }
-napi = { version = "2.16.17", default-features = false, features = ["napi6", "tokio_rt"] }
+napi = { version = "2.16.17", default-features = false, features = ["napi8", "tokio_rt"] }
 napi-derive = "2.16.13"
 ahash = "0.8.11"
 serde_json = "1.0.133"

--- a/README.md
+++ b/README.md
@@ -99,8 +99,8 @@ The binding is compatible with, and tested against, the Node.js
 versions that are in “current” or “active” states,
 according to [the Node.js Releases
 Page](https://nodejs.org/en/about/releases/), _and_ which are
-compatible with [NAPI v6 (Node.js
-API)](https://nodejs.org/api/n-api.html#node-api-version-matrix). It
+compatible with [Node-API (formerly N-API)
+v8)](https://nodejs.org/api/n-api.html#node-api-version-matrix). It
 means that this binding will work with the following versions:
 v24 and v26.
 


### PR DESCRIPTION
Version 8 is the highest version of Node-API supported by napi-rs@^2.16 ([reference](https://docs.rs/napi/2.16.17/napi/#napi1--napi8)), and is backwards-compatible with prior versions ([reference](https://nodejs.org/docs/latest/api/n-api.html#node-api-version-matrix)).  So there should be no harm in bumping the Node-API version to build for to 8.