### PR TITLE
Add arm64 musl to prebuilt list

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,6 +87,9 @@ jobs:
           - target: x86_64-unknown-linux-musl
             os: ubuntu-22.04
             apt_install: musl-tools
+          - target: aarch64-unknown-linux-musl
+            os: ubuntu-22.04
+            apt_install: musl-tools
           - target: s390x-unknown-linux-gnu
             os: ubuntu-22.04
             apt_install: gcc-s390x-linux-gnu g++-s390x-linux-gnu

--- a/README.md
+++ b/README.md
@@ -31,8 +31,12 @@ When installing, NPM will download the corresponding prebuilt Rust library for y
   <tbody>
     <tr>
       <td rowspan="6">Linux</td>
-      <td rowspan="2"><code>aarch</code></td>
+      <td rowspan="3"><code>aarch</code></td>
       <td><code>aarch64-unknown-linux-gnu</code></td>
+      <td>✅</td>
+    </tr>
+    <tr>
+      <td><code>aarch64-unknown-linux-musl</code></td>
       <td>✅</td>
     </tr>
     <tr>

--- a/download-lib.js
+++ b/download-lib.js
@@ -108,7 +108,7 @@ switch (platform) {
                 break;
             case "arm64":
                 if (isMusl()) {
-                    throw new Error("Linux for arm64 musl isn't support at the moment");
+                    download_lib("matrix-sdk-crypto.linux-arm64-musl.node");
                 } else {
                     download_lib("matrix-sdk-crypto.linux-arm64-gnu.node");
                 }


### PR DESCRIPTION
Ran into the problem while trying to move Draupnir to Alpine Based docker image that well Arm64 has no prebuilt musl version of this package. (Ran into this as we ship a multi arch image that ships both amd64 and arm64)

So Cat decided to go and try to add this. This is essentially a copy paste of the amd64 version but to arm64.

As i did not spin up a whole virtual machine for testing this out this is not tested beyond a it looks sane.

Signed-off-by: Catalan Lover <catalanlover@protonmail.com>