### PR TITLE
Disable automatic room key forwarding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## UNRELEASED
 
+-   Disable automatic room key forwarding. ([#95](https://github.com/matrix-org/matrix-rust-sdk-crypto-nodejs/pull/95))
+
 ## v0.6.1 - 2026-06-12
 
 -   Update matrix-rust-sdk to `0.18.0`:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ zeroize = "1.8.1"
 [dependencies.matrix-sdk-crypto]
 version = "0.18.0"
 default-features = false
-features = ["js", "automatic-room-key-forwarding"]
+features = ["js"]
 
 [build-dependencies]
 napi-build = "2.1.3"


### PR DESCRIPTION
We decided that automatic room key forwarding caused more problems than it solved, and have disabled it elsewhere. Apparently we forgot to do it in these bindings.