### PR TITLE
Add `OlmMachine::query_keys_for_users`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 -   Update matrix-rust-sdk to `90db5fe3`.
 -   Disable automatic room key forwarding. ([#95](https://github.com/matrix-org/matrix-rust-sdk-crypto-nodejs/pull/95))
 -   Add prebuilt binary for `linux-riscv64-gnu`. ([#45](https://github.com/matrix-org/matrix-rust-sdk-crypto-nodejs/pull/45))
+-   Add method `OlmMachine.queryKeysForUsers` to build an out-of-band key request. ([#96](https://github.com/matrix-org/matrix-rust-sdk-crypto-nodejs/pull/96))
 
 ## v0.6.1 - 2026-06-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,10 @@
 
 ## UNRELEASED
 
+-   Add method `OlmMachine.queryKeysForUsers` to build an out-of-band key request. ([#96](https://github.com/matrix-org/matrix-rust-sdk-crypto-nodejs/pull/96))
 -   Update matrix-rust-sdk to `90db5fe3`.
 -   Disable automatic room key forwarding. ([#95](https://github.com/matrix-org/matrix-rust-sdk-crypto-nodejs/pull/95))
 -   Add prebuilt binary for `linux-riscv64-gnu`. ([#45](https://github.com/matrix-org/matrix-rust-sdk-crypto-nodejs/pull/45))
--   Add method `OlmMachine.queryKeysForUsers` to build an out-of-band key request. ([#96](https://github.com/matrix-org/matrix-rust-sdk-crypto-nodejs/pull/96))
 
 ## v0.6.1 - 2026-06-12
 

--- a/src/machine.rs
+++ b/src/machine.rs
@@ -423,6 +423,30 @@ impl OlmMachine {
             .collect()
     }
 
+    /// Generate an "out-of-band" key query request for the given set of users.
+    ///
+    /// This can be useful if we need the results from `getIdentity` or
+    /// `getUserDevices` to be as up-to-date as possible.
+    ///
+    /// Returns a `KeysQueryRequest` object. The response of the request should
+    /// be passed to the `OlmMachine` with the `mark_request_as_sent`.
+    ///
+    /// # Arguments
+    ///
+    /// * `users`, the list of users to generate key query requests for.
+    #[napi(strict)]
+    pub fn query_keys_for_users(
+        &self,
+        users: Vec<&identifiers::UserId>,
+    ) -> napi::Result<requests::KeysQueryRequest> {
+        let users = users.into_iter().map(|user| user.inner.clone()).collect::<Vec<_>>();
+
+        let (request_id, request) =
+            self.inner.query_keys_for_users(users.iter().map(AsRef::as_ref));
+
+        Ok(requests::KeysQueryRequest::try_from((request_id.to_string(), &request))?)
+    }
+
     /// Encrypt a JSON-encoded content for the given room.
     ///
     /// # Arguments

--- a/tests/machine.test.js
+++ b/tests/machine.test.js
@@ -433,6 +433,23 @@ describe(OlmMachine.name, () => {
         expect(await m.updateTrackedUsers([user])).toStrictEqual(undefined);
     });
 
+    describe("queryKeysForUsers", () => {
+        test("can build a key query request", async () => {
+            const m = await machine();
+            const request = m.queryKeysForUsers([user]);
+            expect(request).toBeInstanceOf(KeysQueryRequest);
+            const body = JSON.parse(request.body);
+            expect(Object.keys(body.device_keys)).toContain(user.toString());
+        });
+
+        test("cannot use an invalid user ID", async () => {
+            const m = await machine();
+            expect(() => {
+                m.queryKeysForUsers([user.localpart]);
+            }).toThrow();
+        });
+    });
+
     test("can read cross-signing status", async () => {
         const m = await machine();
         const crossSigningStatus = await m.crossSigningStatus();


### PR DESCRIPTION
Allow building an out-of-band key request.

... based heavily on the same thing in `matrix-sdk-crypto-wasm`.