### PR TITLE
Correct README instructions for tracing build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## UNRELEASED
 
+-   Correct the README's instructions for how to build with tracing enabled. ([#97](https://github.com/matrix-org/matrix-rust-sdk-crypto-nodejs/pull/97))
 -   Add method `OlmMachine.queryKeysForUsers` to build an out-of-band key request. ([#96](https://github.com/matrix-org/matrix-rust-sdk-crypto-nodejs/pull/96))
 -   Update matrix-rust-sdk to `90db5fe3`.
 -   Disable automatic room key forwarding. ([#95](https://github.com/matrix-org/matrix-rust-sdk-crypto-nodejs/pull/95))

--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ logs, you should re-compile the extension with the `tracing` feature
 turned on:
 
 ```sh
-$ pnpm build -- --features tracing
+$ pnpm build --features tracing
 ```
 
 Now, you can use the `MATRIX_LOG` environment variable to tweak the log filtering, such as:


### PR DESCRIPTION
The double-dash separator does not work in pnpm